### PR TITLE
Fix AttributeError on ExternalStoryBlock get_prep_value

### DIFF
--- a/wagtail_webstories/blocks.py
+++ b/wagtail_webstories/blocks.py
@@ -97,6 +97,8 @@ class ExternalStoryBlock(blocks.URLBlock):
         # serialisable value should be a URL string
         if value is None:
             return ''
+        elif isinstance(value, str):
+            return value
         else:
             return value.url
 


### PR DESCRIPTION
Avoid exception `AttributeError: 'str' object has no attribute 'url'` on `ExternalStoryBlock.get_prep_value` when an string is returned