### PR TITLE
Support/wagtail 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ on:
 # - django 4.0, python 3.9, wagtail 4.2, sqlite
 # - django 4.1, python 3.10, wagtail 5.0, postgres
 # - django 4.2, python 3.11, wagtail 5.0, sqlite
-# - django 3.2, python 3.10, wagtail main, sqlite (allow failures)
+# - django 4.1, python 3.10, wagtail 5.1, postgres
+# - django 4.2, python 3.11, wagtail 5.1, sqlite
+# - django 4.2, python 3.11, wagtail main, sqlite (allow failures)
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -39,9 +41,19 @@ jobs:
             wagtail: "wagtail>=5.0,<5.1"
             database: "sqlite3"
             experimental: false
+          - python: "3.10"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.1,<5.2"
+            database: "postgresql"
+            experimental: false
+          - python: "3.11"
+            django: "Django>=4.2,<4.3"
+            wagtail: "wagtail>=5.1,<5.2"
+            database: "sqlite3"
+            experimental: false
 
           - python: "3.11"
-            django: "Django>=4.1,<4.2"
+            django: "Django>=4.2,<4.3"
             wagtail: "git+https://github.com/wagtail/wagtail.git@main#egg=wagtail"
             database: "sqlite3"
             experimental: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Update for Wagtail 5.1
+
+
 0.1 (2023-07-27)
 ----------------
 

--- a/wagtail_webstories/templates/wagtail_webstories/admin/import.html
+++ b/wagtail_webstories/templates/wagtail_webstories/admin/import.html
@@ -27,7 +27,7 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
                     {% endif %}
                 {% endfor %}
                 <li><input type="submit" value="{% trans 'Import' %}" class="button" /></li>

--- a/wagtail_webstories/templates/wagtail_webstories/admin/import.html
+++ b/wagtail_webstories/templates/wagtail_webstories/admin/import.html
@@ -27,7 +27,7 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                        <li>{% include "wagtailadmin/shared/field.html" with field=field %}</li>
                     {% endif %}
                 {% endfor %}
                 <li><input type="submit" value="{% trans 'Import' %}" class="button" /></li>


### PR DESCRIPTION
# Wagtail v5.1 update

The changes here are mainly to add some extra versions to the test matrix.

I have made a change to one of the overridden templates: https://github.com/torchbox/wagtail-webstories/pull/23/commits/ee53525c10afb3e66f269455a2c212a1362f653a but it's not likely to be a required change for wagtail v5.1