### PR TITLE
Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,20 @@ on:
 
 # Current configuration:
 # - django 3.2, python 3.8, wagtail 4.1, postgres
-# - django 4.0, python 3.9, wagtail 4.2, sqlite
-# - django 4.1, python 3.10, wagtail 5.0, postgres
-# - django 4.2, python 3.11, wagtail 5.0, sqlite
-# - django 4.1, python 3.10, wagtail 5.1, postgres
-# - django 4.2, python 3.11, wagtail 5.1, sqlite
+# - django 4.1, python 3.8, wagtail 4.1, sqlite
+# - django 3.2, python 3.8, wagtail 5.2, postgres
+# - django 4.1, python 3.8, wagtail 5.2, sqlite
+# - django 3.2, python 3.9, wagtail 4.1, postgres
+# - django 4.1, python 3.9, wagtail 4.1, sqlite
+# - django 3.2, python 3.9, wagtail 5.2, postgres
+# - django 4.1, python 3.9, wagtail 5.2, sqlite
+# - django 3.2, python 3.10, wagtail 4.1, postgres
+# - django 4.1, python 3.10, wagtail 4.1, sqlite
+# - django 3.2, python 3.10, wagtail 5.2, postgres
+# - django 4.1, python 3.10, wagtail 5.2, sqlite
+# - django 4.1, python 3.11, wagtail 4.1, sqlite
+# - django 4.1, python 3.11, wagtail 5.2, sqlite
+# - django 4.2, python 3.11, wagtail 5.2, sqlite
 # - django 4.2, python 3.11, wagtail main, sqlite (allow failures)
 jobs:
   test:
@@ -26,30 +35,75 @@ jobs:
             wagtail: "wagtail>=4.1,<4.2"
             database: "postgresql"
             experimental: false
+          - python: "3.8"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=4.1,<4.2"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.8"
+            django: "Django>=3.2,<4.0"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "postgresql"
+            experimental: false
+          - python: "3.8"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "sqlite3"
+            experimental: false
           - python: "3.9"
-            django: "Django>=4.0,<4.1"
-            wagtail: "wagtail>=4.2,<5.0"
+            django: "Django>=3.2,<4.0"
+            wagtail: "wagtail>=4.1,<4.2"
+            database: "postgresql"
+            experimental: false
+          - python: "3.9"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=4.1,<4.2"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.9"
+            django: "Django>=3.2,<4.0"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "postgresql"
+            experimental: false
+          - python: "3.9"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.2,<5.3"
             database: "sqlite3"
             experimental: false
           - python: "3.10"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.0,<5.1"
+            django: "Django>=3.2,<4.0"
+            wagtail: "wagtail>=4.1,<4.2"
             database: "postgresql"
-            experimental: false
-          - python: "3.11"
-            django: "Django>=4.2,<4.3"
-            wagtail: "wagtail>=5.0,<5.1"
-            database: "sqlite3"
             experimental: false
           - python: "3.10"
             django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.1,<5.2"
+            wagtail: "wagtail>=4.1,<4.2"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.10"
+            django: "Django>=3.2,<4.0"
+            wagtail: "wagtail>=5.2,<5.3"
             database: "postgresql"
+            experimental: false
+          - python: "3.10"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.11"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=4.1,<4.2"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.11"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "sqlite3"
             experimental: false
           - python: "3.11"
             django: "Django>=4.2,<4.3"
-            wagtail: "wagtail>=5.1,<5.2"
-            database: "sqlite3"
+            wagtail: "wagtail>=5.2,<5.3"
+            database: "postgresql"
             experimental: false
 
           - python: "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,21 +8,11 @@ on:
 
 # Current configuration:
 # - django 3.2, python 3.8, wagtail 4.1, postgres
-# - django 4.1, python 3.8, wagtail 4.1, sqlite
-# - django 3.2, python 3.8, wagtail 5.2, postgres
-# - django 4.1, python 3.8, wagtail 5.2, sqlite
-# - django 3.2, python 3.9, wagtail 4.1, postgres
-# - django 4.1, python 3.9, wagtail 4.1, sqlite
-# - django 3.2, python 3.9, wagtail 5.2, postgres
-# - django 4.1, python 3.9, wagtail 5.2, sqlite
-# - django 3.2, python 3.10, wagtail 4.1, postgres
-# - django 4.1, python 3.10, wagtail 4.1, sqlite
-# - django 3.2, python 3.10, wagtail 5.2, postgres
-# - django 4.1, python 3.10, wagtail 5.2, sqlite
-# - django 4.1, python 3.11, wagtail 4.1, sqlite
-# - django 4.1, python 3.11, wagtail 5.2, sqlite
+# - django 3.2, python 3.9, wagtail 5.1, sqlite
+# - django 4.1, python 3.10, wagtail 5.1, postgres
 # - django 4.2, python 3.11, wagtail 5.2, sqlite
-# - django 4.2, python 3.11, wagtail main, sqlite (allow failures)
+# - django 4.2, python 3.12, wagtail 5.2, postgres
+# - django 4.2, python 3.12, wagtail main, sqlite (allow failures)
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,78 +25,27 @@ jobs:
             wagtail: "wagtail>=4.1,<4.2"
             database: "postgresql"
             experimental: false
-          - python: "3.8"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=4.1,<4.2"
-            database: "sqlite3"
-            experimental: false
-          - python: "3.8"
-            django: "Django>=3.2,<4.0"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "postgresql"
-            experimental: false
-          - python: "3.8"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "sqlite3"
-            experimental: false
           - python: "3.9"
             django: "Django>=3.2,<4.0"
-            wagtail: "wagtail>=4.1,<4.2"
-            database: "postgresql"
-            experimental: false
-          - python: "3.9"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=4.1,<4.2"
-            database: "sqlite3"
-            experimental: false
-          - python: "3.9"
-            django: "Django>=3.2,<4.0"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "postgresql"
-            experimental: false
-          - python: "3.9"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.2,<5.3"
+            wagtail: "wagtail>=5.1,<5.2"
             database: "sqlite3"
             experimental: false
           - python: "3.10"
-            django: "Django>=3.2,<4.0"
-            wagtail: "wagtail>=4.1,<4.2"
+            django: "Django>=4.1,<4.2"
+            wagtail: "wagtail>=5.1,<5.2"
             database: "postgresql"
-            experimental: false
-          - python: "3.10"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=4.1,<4.2"
-            database: "sqlite3"
-            experimental: false
-          - python: "3.10"
-            django: "Django>=3.2,<4.0"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "postgresql"
-            experimental: false
-          - python: "3.10"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "sqlite3"
-            experimental: false
-          - python: "3.11"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=4.1,<4.2"
-            database: "sqlite3"
-            experimental: false
-          - python: "3.11"
-            django: "Django>=4.1,<4.2"
-            wagtail: "wagtail>=5.2,<5.3"
-            database: "sqlite3"
             experimental: false
           - python: "3.11"
             django: "Django>=4.2,<4.3"
             wagtail: "wagtail>=5.2,<5.3"
+            database: "sqlite3"
+            experimental: false
+          - python: "3.12"
+            django: "Django>=4.2,<4.3"
+            wagtail: "wagtail>=5.2,<5.3"
             database: "postgresql"
             experimental: false
-
-          - python: "3.11"
+          - python: "3.12"
             django: "Django>=4.2,<4.3"
             wagtail: "git+https://github.com/wagtail/wagtail.git@main#egg=wagtail"
             database: "sqlite3"

--- a/wagtail_webstories/wagtail_hooks.py
+++ b/wagtail_webstories/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.urls import include, path, reverse
 
-from wagtail import hooks
+from wagtail import hooks, VERSION as WAGTAIL_VERSION
 from wagtail.admin.menu import MenuItem
 
 from . import admin_urls
@@ -17,4 +17,9 @@ if getattr(settings, 'WAGTAIL_WEBSTORIES_IMPORT_MODEL', None):
 
     @hooks.register('register_admin_menu_item')
     def register_webstories_item():
-        return MenuItem('Web stories', reverse('wagtail_webstories:import_story'), classnames='icon icon-openquote', order=10000)
+        if WAGTAIL_VERSION >= (5, 2):
+            kwargs = {"classname": "icon icon-openquote"}
+        else:
+            kwargs = {"classnames": "icon icon-openquote"}
+
+        return MenuItem('Web stories', reverse('wagtail_webstories:import_story'), order=10000, **kwargs)


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

Upgrade considerations:
- [Adoption of classname convention for MenuItem related classes and hooks
](https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks)

Other changes:
- Update test matrix to include Wagtail 5.2