### PR TITLE
Wagtail 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 
 * Drop support for Wagtail < 5.2
 * Add support for Django 5.0
+* Drop support for Django < 4.2
 
 0.1.1 (2023-11-24)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
     extras_require={
         "testing": [
             "responses>=0.12,<1",
-            "Pillow>=4.0.0,<10.0.0",
-            "wagtailmedia>=0.6,<0.15",
+            "Pillow>=4.0.0,<11.0.0",
+            "wagtailmedia>=0.6,<0.16",
         ]
     },
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Wagtail",

--- a/tests/tests/test_editing.py
+++ b/tests/tests/test_editing.py
@@ -5,14 +5,14 @@ from django.test import override_settings
 
 from wagtail.images.models import Image
 from wagtail.models import Page
-from wagtail.test.utils import WagtailPageTests
+from wagtail.test.utils import WagtailPageTestCase
 from wagtail.test.utils.form_data import nested_form_data, streamfield
 
 from tests.models import StoryPage
 from tests.utils import get_test_image_file, TEST_MEDIA_DIR
 
 
-class TestEditing(WagtailPageTests):
+class TestEditing(WagtailPageTestCase):
     def setUp(self):
         shutil.rmtree(TEST_MEDIA_DIR, ignore_errors=True)
         self.user = User.objects.create_superuser(username='admin', email='admin@example.com', password='12345')

--- a/wagtail_webstories/wagtail_hooks.py
+++ b/wagtail_webstories/wagtail_hooks.py
@@ -17,9 +17,9 @@ if getattr(settings, 'WAGTAIL_WEBSTORIES_IMPORT_MODEL', None):
 
     @hooks.register('register_admin_menu_item')
     def register_webstories_item():
-        if WAGTAIL_VERSION >= (5, 2):
-            kwargs = {"classname": "icon icon-openquote"}
-        else:
-            kwargs = {"classnames": "icon icon-openquote"}
-
-        return MenuItem('Web stories', reverse('wagtail_webstories:import_story'), order=10000, **kwargs)
+        return MenuItem(
+            'Web stories',
+            reverse('wagtail_webstories:import_story'),
+            icon_name="openquote",
+            order=10000,
+        )


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

<details>
<summary>Wagtail 6.1 upgrade check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>